### PR TITLE
Seperate file for thermocouple functions

### DIFF
--- a/VC/instrumentation/read_labjack.py
+++ b/VC/instrumentation/read_labjack.py
@@ -178,6 +178,21 @@ if samples_per_packet < len(channel_settings):
              ") must be at least the number of channels: (" + \
              str(len(channel_settings)) + ")!")
 
+Tref = d.getTemperature() - 273.15
+
+c0 = -1.7600413686 * 10**-2
+c1 = 3.8921204975 * 10**-2
+c2 = 1.8558770032 * 10**-5
+c3 = -9.9457592874 * 10**-8
+c4 = 3.1840945719 * 10**-10
+c5 = -5.6072844889 * 10**-13
+c6 = 5.6075059059 * 10**-16
+c7 = -3.2020720003 * 10**-19
+c8 = 9.7151147152 * 10**-23
+c9 = -1.2104721275 * 10**-26
+
+voltage_reference = c0 + c1*Tref + c2*Tref**2 + c3*Tref**3 + c4*Tref**4 + c5*Tref**5 + c6*Tref**6 + c7*Tref**7 + c8*Tref**8 + c9*Tref**9
+
 # Stream data from the LJ
 d.streamStart()
 
@@ -236,14 +251,65 @@ with open('instrumentation_data.txt', 'w') as file:
             (sum(L_THRUST)/len(L_THRUST))*GAIN_L_THRUST+OFFSET_L_THRUST
 
             # TODO these need to be proper thermocouple conversions
-            converted['T_RUN_TANK'] = (sum(T_RUN_TANK)/len(T_RUN_TANK))
-            converted['T_INJECTOR'] = (sum(T_INJECTOR)/len(T_INJECTOR))
-            converted['T_COMB_CHMBR'] = (sum(T_COMB_CHMBR)/len(T_COMB_CHMBR))
-            converted['T_POST_COMB'] = (sum(T_POST_COMB)/len(T_POST_COMB))
+            converted['T_RUN_TANK'] = voltagetokelvin((sum(T_RUN_TANK)/len(T_RUN_TANK)))
+            converted['T_INJECTOR'] = voltagetokelvin((sum(T_INJECTOR)/len(T_INJECTOR)))
+            converted['T_COMB_CHMBR'] = voltagetokelvin((sum(T_COMB_CHMBR)/len(T_COMB_CHMBR)))
+            converted['T_POST_COMB'] = voltagetokelvin((sum(T_POST_COMB)/len(T_POST_COMB)))
 
             # Write to file so websocket can send to ground support
             file.write(f'{json.dumps(converted)}\n')
 
+#Function to turn thermocouple voltages to kelvin
+def voltagetokelvin(voltage):
+    voltage_actual = voltage + voltage_reference
+    if voltage > 0.020644 and voltage < 0.054886:
+        C0 = -131.8058
+        C1 = 48.30222
+        C2 = -1.646031 
+        C3 = 0.05464731
+        C4 = -0.0009650715
+        C5 = 0.000008802193
+        C6 = -0.00000003110810
+        C7 = 0
+        C8 = 0
+        C9 = 0
+    elif voltage > -0.005891 and voltage < 0:
+        C0 = 0
+        C1 = 25.173462
+        C2 = -1.1662878
+        C3 = -1.0833638
+        C4 = -0.89773540
+        C5 = -0.37342377
+        C6 = -0.086632643
+        C7 = -0.010450598
+        C8 = -0.00051920577
+        C9 = 0
+    elif voltage > 0 and voltage < 0.020644:
+        C0 = 0
+        C1 = 25.08355
+        C2 = 0.07860106
+        C3 = -0.2503131
+        C4 = 0.08315270
+        C5 = -0.01228034
+        C6 = 0.0009804036
+        C7 = -0.0000413030
+        C8 = 0.000001057734
+        C9 = -0.00000001052755
+    else:
+        C0 = 0
+        C1 = 0
+        C2 = 0
+        C3 = 0
+        C4 = 0
+        C5 = 0
+        C6 = 0
+        C7 = 0
+        C8 = 0
+        C9 = 0
+        print("Thermocouple voltage out of range   ", voltage_actual)
+    
+    tempC = C0 + C1*voltage_actual + C2*voltage_actual**2 + C3*voltage_actual**3 + C4*voltage_actual**4 + C5*voltage_actual**5 + C6*voltage_actual**6 + C7*voltage_actual**7 + C8*voltage_actual**8 + C9*voltage_actual**9
+    return (tempC + 273.15)
 
 
 

--- a/VC/instrumentation/read_labjack.py
+++ b/VC/instrumentation/read_labjack.py
@@ -1,5 +1,6 @@
 import u6
 import json
+from thermocouple import *
 
 # Gains
 X1    = 0b00000000
@@ -178,21 +179,6 @@ if samples_per_packet < len(channel_settings):
              ") must be at least the number of channels: (" + \
              str(len(channel_settings)) + ")!")
 
-Tref = d.getTemperature() - 273.15
-
-c0 = -1.7600413686 * 10**-2
-c1 = 3.8921204975 * 10**-2
-c2 = 1.8558770032 * 10**-5
-c3 = -9.9457592874 * 10**-8
-c4 = 3.1840945719 * 10**-10
-c5 = -5.6072844889 * 10**-13
-c6 = 5.6075059059 * 10**-16
-c7 = -3.2020720003 * 10**-19
-c8 = 9.7151147152 * 10**-23
-c9 = -1.2104721275 * 10**-26
-
-voltage_reference = c0 + c1*Tref + c2*Tref**2 + c3*Tref**3 + c4*Tref**4 + c5*Tref**5 + c6*Tref**6 + c7*Tref**7 + c8*Tref**8 + c9*Tref**9
-
 # Stream data from the LJ
 d.streamStart()
 
@@ -258,74 +244,3 @@ with open('instrumentation_data.txt', 'w') as file:
 
             # Write to file so websocket can send to ground support
             file.write(f'{json.dumps(converted)}\n')
-
-#Function to turn thermocouple voltages to kelvin
-def voltagetokelvin(voltage):
-    voltage_actual = voltage + voltage_reference
-    if voltage > 0.020644 and voltage < 0.054886:
-        C0 = -131.8058
-        C1 = 48.30222
-        C2 = -1.646031 
-        C3 = 0.05464731
-        C4 = -0.0009650715
-        C5 = 0.000008802193
-        C6 = -0.00000003110810
-        C7 = 0
-        C8 = 0
-        C9 = 0
-    elif voltage > -0.005891 and voltage < 0:
-        C0 = 0
-        C1 = 25.173462
-        C2 = -1.1662878
-        C3 = -1.0833638
-        C4 = -0.89773540
-        C5 = -0.37342377
-        C6 = -0.086632643
-        C7 = -0.010450598
-        C8 = -0.00051920577
-        C9 = 0
-    elif voltage > 0 and voltage < 0.020644:
-        C0 = 0
-        C1 = 25.08355
-        C2 = 0.07860106
-        C3 = -0.2503131
-        C4 = 0.08315270
-        C5 = -0.01228034
-        C6 = 0.0009804036
-        C7 = -0.0000413030
-        C8 = 0.000001057734
-        C9 = -0.00000001052755
-    else:
-        C0 = 0
-        C1 = 0
-        C2 = 0
-        C3 = 0
-        C4 = 0
-        C5 = 0
-        C6 = 0
-        C7 = 0
-        C8 = 0
-        C9 = 0
-        print("Thermocouple voltage out of range   ", voltage_actual)
-    
-    tempC = C0 + C1*voltage_actual + C2*voltage_actual**2 + C3*voltage_actual**3 + C4*voltage_actual**4 + C5*voltage_actual**5 + C6*voltage_actual**6 + C7*voltage_actual**7 + C8*voltage_actual**8 + C9*voltage_actual**9
-    return (tempC + 273.15)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/VC/instrumentation/thermocouple.py
+++ b/VC/instrumentation/thermocouple.py
@@ -1,12 +1,12 @@
-import u6
+# Get voltage of cold junction of LabJack
+def get_ref_voltage(T_cold_junction_K):
 
+    # T_cold_junction is in K from: d.getTemperature()
 
-d = u6.U6()
+    # Coeffs expect Celsius 
+    Tref = T_cold_junction_K - 273.15
 
-#Get starting reference temp of LabJack
-def get_ref_temp():
-    Tref = d.getTemperature() - 273.15
-
+    # For 0C to 1372C at reduced accuracy
     c0 = -1.7600413686 * 10**-2
     c1 = 3.8921204975 * 10**-2
     c2 = 1.8558770032 * 10**-5
@@ -18,21 +18,26 @@ def get_ref_temp():
     c8 = 9.7151147152 * 10**-23
     c9 = -1.2104721275 * 10**-26
 
-    voltage_reference = c0 + \
-                        c1*Tref + \
-                        c2*Tref**2 + \
-                        c3*Tref**3 + \
-                        c4*Tref**4 + \
-                        c5*Tref**5 + \
-                        c6*Tref**6 + \
-                        c7*Tref**7 + \
-                        c8*Tref**8 + \
-                        c9*Tref**9
-    return voltage_reference
+    mV = c0 + \
+         c1*Tref + \
+         c2*Tref**2 + \
+         c3*Tref**3 + \
+         c4*Tref**4 + \
+         c5*Tref**5 + \
+         c6*Tref**6 + \
+         c7*Tref**7 + \
+         c8*Tref**8 + \
+         c9*Tref**9
 
-#Function to turn thermocouple voltages to kelvin
-def v_to_K(voltage, ref_voltage = 0):
-    voltage_actual = voltage + ref_voltage
+    # This computes the voltage in mV so convert to V
+    return mV/1000
+
+# Function to turn thermocouple voltages to kelvin
+def V_to_K(tc_voltage, ref_voltage):
+
+    voltage = (tc_voltage+ref_voltage)
+
+    # Ranges based on volts and celsius
     if voltage > 0.020644 and voltage < 0.054886:
         C0 = -131.8058
         C1 = 48.30222
@@ -69,17 +74,17 @@ def v_to_K(voltage, ref_voltage = 0):
     else:
        return 0
     
-    voltage_actual = voltage_actual*1000
-
+    # Coeffs expect mV
+    mV_voltage = voltage * 1000
     tempC = C0 + \
-            C1*voltage_actual + \
-            C2*voltage_actual**2 + \
-            C3*voltage_actual**3 + \
-            C4*voltage_actual**4 + \
-            C5*voltage_actual**5 + \
-            C6*voltage_actual**6 + \
-            C7*voltage_actual**7 + \
-            C8*voltage_actual**8 + \
-            C9*voltage_actual**9
+            C1*mV_voltage + \
+            C2*mV_voltage**2 + \
+            C3*mV_voltage**3 + \
+            C4*mV_voltage**4 + \
+            C5*mV_voltage**5 + \
+            C6*mV_voltage**6 + \
+            C7*mV_voltage**7 + \
+            C8*mV_voltage**8 + \
+            C9*mV_voltage**9
    
     return (tempC + 273.15)

--- a/VC/instrumentation/thermocouple.py
+++ b/VC/instrumentation/thermocouple.py
@@ -1,0 +1,85 @@
+import u6
+
+
+d = u6.U6()
+
+#Get starting reference temp of LabJack
+def get_ref_temp():
+    Tref = d.getTemperature() - 273.15
+
+    c0 = -1.7600413686 * 10**-2
+    c1 = 3.8921204975 * 10**-2
+    c2 = 1.8558770032 * 10**-5
+    c3 = -9.9457592874 * 10**-8
+    c4 = 3.1840945719 * 10**-10
+    c5 = -5.6072844889 * 10**-13
+    c6 = 5.6075059059 * 10**-16
+    c7 = -3.2020720003 * 10**-19
+    c8 = 9.7151147152 * 10**-23
+    c9 = -1.2104721275 * 10**-26
+
+    voltage_reference = c0 + \
+                        c1*Tref + \
+                        c2*Tref**2 + \
+                        c3*Tref**3 + \
+                        c4*Tref**4 + \
+                        c5*Tref**5 + \
+                        c6*Tref**6 + \
+                        c7*Tref**7 + \
+                        c8*Tref**8 + \
+                        c9*Tref**9
+    return voltage_reference
+
+#Function to turn thermocouple voltages to kelvin
+def v_to_K(voltage, ref_voltage = 0):
+    voltage_actual = voltage + ref_voltage
+    if voltage > 0.020644 and voltage < 0.054886:
+        C0 = -131.8058
+        C1 = 48.30222
+        C2 = -1.646031 
+        C3 = 0.05464731
+        C4 = -0.0009650715
+        C5 = 0.000008802193
+        C6 = -0.00000003110810
+        C7 = 0
+        C8 = 0
+        C9 = 0
+    elif voltage > -0.005891 and voltage < 0:
+        C0 = 0
+        C1 = 25.173462
+        C2 = -1.1662878
+        C3 = -1.0833638
+        C4 = -0.89773540
+        C5 = -0.37342377
+        C6 = -0.086632643
+        C7 = -0.010450598
+        C8 = -0.00051920577
+        C9 = 0
+    elif voltage > 0 and voltage < 0.020644:
+        C0 = 0
+        C1 = 25.08355
+        C2 = 0.07860106
+        C3 = -0.2503131
+        C4 = 0.08315270
+        C5 = -0.01228034
+        C6 = 0.0009804036
+        C7 = -0.0000413030
+        C8 = 0.000001057734
+        C9 = -0.00000001052755
+    else:
+       return 0
+    
+    voltage_actual = voltage_actual*1000
+
+    tempC = C0 + \
+            C1*voltage_actual + \
+            C2*voltage_actual**2 + \
+            C3*voltage_actual**3 + \
+            C4*voltage_actual**4 + \
+            C5*voltage_actual**5 + \
+            C6*voltage_actual**6 + \
+            C7*voltage_actual**7 + \
+            C8*voltage_actual**8 + \
+            C9*voltage_actual**9
+   
+    return (tempC + 273.15)


### PR DESCRIPTION
I polished off @BecauseWhyNote's code and added some comments for which units of measure were being used and where. I tested briefly using a heat gun. The thermocouple I used for testing (run tank) reads high at room temp (usually around 300K but should be more like 293K)  but reacts to the heat gun as expected. The LJ internal temp sensor reads 293K. Not sure if this is a logic error, or the coeff's are off or maybe the thermocouple itself is damaged.

Would be good to do some more testing again and try and figure out why there is a 7K discrepancy. It's functional enough for basic monitoring right now though.